### PR TITLE
load jekyll-data plugin out-of-the-box

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ group :test do
   gem "rspec"
   gem "activesupport", "~> 4.2" if RUBY_VERSION < '2.2.2'
   gem "test-theme", path: File.expand_path("./test/fixtures/test-theme", File.dirname(__FILE__))
+  gem "jekyll-data", git: "https://github.com/ashmaroli/jekyll-data.git"
 end

--- a/features/bundled_plugins.feature
+++ b/features/bundled_plugins.feature
@@ -1,0 +1,15 @@
+Feature: Bundled plugins
+  As a hacker who likes added features
+  I want to be able to use certain additonal features out-of-the-box
+  In order to avoid having to manually include same plugins to every new blog
+
+  Scenario: Building a site with a theme that includes data files
+    Given I do not have a "test-site" directory
+    When I run jekyll+ new-site test-site --theme test-theme
+    Then I should get a zero exit status
+    And the test-site directory should exist
+    Given I have moved into the "test-site" directory
+    And I have a "test.md" page that contains "{{ site.data.locales[site.locale].greeting }}"
+    When I run bundle exec jekyll+ build
+    Then I should get a zero exit status
+    And I should see "<p>Bonjour, Bienvenue!</p>" in "_site/test.html"

--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -85,6 +85,12 @@ end
 
 #
 
+Given(%r!^I have moved into the "(.*)" directory$!) do |dir|
+  Dir.chdir(dir)
+end
+
+#
+
 When(%r!^I run jekyll\+(.*)$!) do |args|
   run_jekyll(args)
   if args.include?("--verbose") || ENV["DEBUG"]

--- a/jekyll-plus.gemspec
+++ b/jekyll-plus.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "jekyll", "~> 3.4"
+  spec.add_runtime_dependency "jekyll-data", "~> 0.4"
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/jekyll-plus.rb
+++ b/lib/jekyll-plus.rb
@@ -2,3 +2,6 @@ require "jekyll"
 require "jekyll-plus/version"
 require_relative "jekyll/commands/new_site"
 require_relative "jekyll/commands/extract_theme"
+
+# Plugins
+require "jekyll-data" # read "_config.yml" and data files within a theme-gem

--- a/lib/jekyll/commands/new_site.rb
+++ b/lib/jekyll/commands/new_site.rb
@@ -105,12 +105,11 @@ module Jekyll
           "Templates and _config.yml from #{@theme.cyan} if available..",
           "="
         )
-        package = \
-          %w(
-            _layouts _includes _sass _data assets _config.yml
-          )
+        package = %w(_layouts _includes _sass _data assets _config.yml)
+        package << extraction_opts
+
         Dir.chdir(path) do
-          Commands::ExtractTheme.process(package, extraction_opts)
+          bundle_extract package
         end
       end
 
@@ -120,9 +119,16 @@ module Jekyll
           "_config.yml from theme-gem if available..",
           "="
         )
+        package = %w(_config.yml)
+        package << extraction_opts
+
         Dir.chdir(path) do
-          Commands::ExtractTheme.process(%w(_config.yml), extraction_opts)
+          bundle_extract package
         end
+      end
+
+      def bundle_extract(package)
+        system("bundle", "exec", "jekyll+ extract #{package.join(" ")}")
       end
 
       def extraction_opts

--- a/test/fixtures/test-theme/_config.yml
+++ b/test/fixtures/test-theme/_config.yml
@@ -1,6 +1,10 @@
 # Welcome to Jekyll!
 
 theme: test-theme
-exclude:
-  - Gemfile
-  - Gemfile.lock
+locale: fr
+
+# test with some real-world plugins
+gems:
+  - jemoji
+  - jekyll-mentions
+  - jekyll-paginate

--- a/test/fixtures/test-theme/_data/locales.yml
+++ b/test/fixtures/test-theme/_data/locales.yml
@@ -1,0 +1,14 @@
+en:
+  greeting: "Hello There, Welcome!"
+  prev: previous
+  next: next
+
+  long_strings:
+    - THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG
+    - THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG DOZING UNDER THE CANOPY
+
+fr:
+  greeting: "Bonjour, Bienvenue!"
+  prev: précédent
+  next: prochain
+

--- a/test/fixtures/test-theme/test-theme.gemspec
+++ b/test/fixtures/test-theme/test-theme.gemspec
@@ -4,4 +4,8 @@ Gem::Specification.new do |s|
   s.licenses    = ['MIT']
   s.summary     = "This is a theme used to test JekyllPlus plugin"
   s.authors     = ["JekyllPlus"]
+
+  s.add_dependency "jemoji", "~> 0.8"
+  s.add_dependency "jekyll-mentions", "~> 1.2"
+  s.add_dependency "jekyll-paginate", "~> 1.1"
 end


### PR DESCRIPTION
load [`jekyll-data`](https://github.com/ashmaroli/jekyll-data) plugin out-of-the-box to enable reading data files in `_data` within a theme-gem, especially when `build`ing / `serve`ing with `jekyll+`