### PR TITLE
Apply temporary patches to various modules and classes used by Jekyll

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
     - exe/**/*
     - script/**/*
     - vendor/**/*
+    - lib/patches/*
 Lint/EndAlignment:
   Severity: error
 Lint/UnreachableCode:

--- a/lib/jekyll-plus.rb
+++ b/lib/jekyll-plus.rb
@@ -9,7 +9,12 @@ require "jekyll-data" # read "_config.yml" and data files within a theme-gem
 # ------------------------------ Temporary Patches ------------------------------
 # TODO:
 #   - remove patch to Jekyll Configuration after jekyll/jekyll/pull/5487 is merged.
+#   - modify patch to Mercenary after jekyll/mercenary/pull/44 and
+#     jekyll/mercenary/pull/48 are merged.
 
 require_relative "patches/idempotent_jekyll_config"
+
+require "mercenary"
+require_relative "patches/mercenary_presenter"
 
 # --------------------------- End of Temporary Patches ---------------------------

--- a/lib/jekyll-plus.rb
+++ b/lib/jekyll-plus.rb
@@ -5,3 +5,11 @@ require_relative "jekyll/commands/extract_theme"
 
 # Plugins
 require "jekyll-data" # read "_config.yml" and data files within a theme-gem
+
+# ------------------------------ Temporary Patches ------------------------------
+# TODO:
+#   - remove patch to Jekyll Configuration after jekyll/jekyll/pull/5487 is merged.
+
+require_relative "patches/idempotent_jekyll_config"
+
+# --------------------------- End of Temporary Patches ---------------------------

--- a/lib/jekyll-plus.rb
+++ b/lib/jekyll-plus.rb
@@ -11,10 +11,14 @@ require "jekyll-data" # read "_config.yml" and data files within a theme-gem
 #   - remove patch to Jekyll Configuration after jekyll/jekyll/pull/5487 is merged.
 #   - modify patch to Mercenary after jekyll/mercenary/pull/44 and
 #     jekyll/mercenary/pull/48 are merged.
+#   - remove patch to Jekyll::Watcher after jekyll/jekyll-watch/pull/42 is merged.
 
 require_relative "patches/idempotent_jekyll_config"
 
 require "mercenary"
 require_relative "patches/mercenary_presenter"
+
+require "jekyll-watch"
+require_relative "patches/jekyll_watcher"
 
 # --------------------------- End of Temporary Patches ---------------------------

--- a/lib/jekyll-plus.rb
+++ b/lib/jekyll-plus.rb
@@ -12,6 +12,7 @@ require "jekyll-data" # read "_config.yml" and data files within a theme-gem
 #   - modify patch to Mercenary after jekyll/mercenary/pull/44 and
 #     jekyll/mercenary/pull/48 are merged.
 #   - remove patch to Jekyll::Watcher after jekyll/jekyll-watch/pull/42 is merged.
+#   - remove patch to Listen Adapter only if any issues regarding that crop up.
 
 require_relative "patches/idempotent_jekyll_config"
 
@@ -20,5 +21,8 @@ require_relative "patches/mercenary_presenter"
 
 require "jekyll-watch"
 require_relative "patches/jekyll_watcher"
+
+require "listen"
+require_relative "patches/listen_windows_adapter"
 
 # --------------------------- End of Temporary Patches ---------------------------

--- a/lib/patches/idempotent_jekyll_config.rb
+++ b/lib/patches/idempotent_jekyll_config.rb
@@ -1,0 +1,41 @@
+module Jekyll
+  class Command
+    def self.configuration_from_options(options)
+      return options if options.is_a?(Jekyll::Configuration)
+      Jekyll.configuration(options)
+    end
+  end
+
+  module Commands
+    class Serve < Command
+      class << self
+        def init_with_program(prog)
+          prog.command(:serve) do |cmd|
+            cmd.description "Serve your site locally"
+            cmd.syntax "serve [options]"
+            cmd.alias :server
+            cmd.alias :s
+
+            add_build_options(cmd)
+            COMMAND_OPTIONS.each do |key, val|
+              cmd.option key, *val
+            end
+
+            cmd.action do |_, opts|
+              opts["serving"] = true
+              opts["watch"  ] = true unless opts.key?("watch")
+
+              config = configuration_from_options(opts)
+              if Jekyll.env == "development"
+                config["url"] = default_url(config)
+              end
+
+              Build.process(config)
+              Serve.process(config)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/patches/jekyll_watcher.rb
+++ b/lib/patches/jekyll_watcher.rb
@@ -1,0 +1,59 @@
+require "listen"
+
+module Jekyll
+  module Watcher
+    extend self
+
+    # Returns nothing.
+    def watch(options, site = nil)
+      ENV["LISTEN_GEM_DEBUGGING"] ||= "1" if options["verbose"]
+
+      site ||= Jekyll::Site.new(options)
+      listener = build_listener(site, options)
+      listener.start
+
+      Jekyll.logger.info "Auto-regeneration:", "#{"enabled".green} for #{options["source"]}"
+
+      unless options["serving"]
+        trap("INT") do
+          listener.stop
+          puts "     Halting auto-regeneration."
+          exit 0
+        end
+
+        sleep_forever
+      end
+    rescue ThreadError
+      # You pressed Ctrl-C, oh my!
+    end
+
+    def listen_handler(site)
+      proc do |modified, added, removed|
+        t = Time.now
+        c = modified + added + removed
+        n = c.length
+        Jekyll.logger.info("Regenerating:",
+          "#{n} file(s) changed at #{t.strftime("%Y-%m-%d %H:%M:%S")} ")
+        relative_paths = c.map { |p| site.in_source_dir(p) }
+        relative_paths.each { |file| Jekyll.logger.info "", file.cyan }
+        process site, t
+      end
+    end
+
+    private
+
+    def process(site, time)
+      site.process
+      Jekyll.logger.info "", "...done in #{Time.now - time} seconds.".green
+      print_clear_line
+    rescue => e
+      Jekyll.logger.warn "Error:", e.message
+      Jekyll.logger.warn "Error:", "Run jekyll build --trace for more information."
+      print_clear_line
+    end
+
+    def print_clear_line
+      Jekyll.logger.info ""
+    end
+  end
+end

--- a/lib/patches/listen_windows_adapter.rb
+++ b/lib/patches/listen_windows_adapter.rb
@@ -1,0 +1,8 @@
+module Listen
+  module Adapter
+    class Windows < Base
+      def self.usable?
+      end
+    end
+  end
+end

--- a/lib/patches/mercenary_presenter.rb
+++ b/lib/patches/mercenary_presenter.rb
@@ -1,0 +1,38 @@
+module Mercenary
+  class Presenter
+    attr_accessor :command
+
+    def options_presentation
+      return nil unless command_options_presentation || parent_command_options_presentation
+      [command_options_presentation.cyan, parent_command_options_presentation].join("\n\n").rstrip
+    end
+
+    def parent_command_options_presentation
+      return nil unless command.parent
+      Presenter.new(command.parent).command_options_presentation
+    end
+
+    # adapted from https://github.com/jekyll/mercenary/pull/44
+    def command_options_presentation
+      return nil if command.options.empty?
+      command_options = command.options
+      command_options -= command.parent.options unless command.parent.nil?
+      command_options.map(&:to_s).join("\n")
+    end
+
+    def command_header
+      header = "\n#{command.identity}"
+      header << " -- #{command.description}" if command.description
+      header
+    end
+  end
+
+  class Option
+    def formatted_switches
+      [
+        switches.first.rjust(10),
+        switches.last.ljust(20)
+      ].join(", ").gsub(/ , /, '   ').gsub(/,   /, '    ')
+    end
+  end
+end


### PR DESCRIPTION
The patches are adapted from existing pull requests at the respective repositories as noted in the comments and have made a few minor alterations to them as I saw fit.

The patch to `Listen` removes the `require` for `gem 'wdm'` on Windows, as `jekyll-watch` works fine on my Windows machine.
TODO: test this when AppVeyor is enabled in this repo

No tests for these patches as they're only temporary inclusions as of now.