### PR TITLE
Add a --root switch to extract-theme command

### DIFF
--- a/features/extract_theme.feature
+++ b/features/extract_theme.feature
@@ -52,6 +52,26 @@ Feature: Extracting theme contents to source
     And the "assets/style.scss" file should exist
     And the "assets/img/logo.png" file should exist
 
+  Scenario: Extracting contents of sub-directories directly to site's source without --force
+    Given I have a configuration file with "theme" set to "test-theme"
+    When I run jekyll+ extract-theme assets _data/locales.yml --root
+    Then I should get a zero exit status
+    And the assets directory should not exist
+    And the _data directory should not exist
+    And the "style.scss" file should not exist
+    And the "img/logo.png" file should not exist
+    But the "locales.yml" file should exist
+
+  Scenario: Extracting contents of sub-directories directly to site's source with --force
+    Given I have a configuration file with "theme" set to "test-theme"
+    When I run jekyll+ extract-theme assets _data/locales.yml --root --force
+    Then I should get a zero exit status
+    And the assets directory should not exist
+    And the _data directory should not exist
+    But the "style.scss" file should exist
+    And the "img/logo.png" file should exist
+    And the "locales.yml" file should exist
+
   Scenario: Extracting only a specific file
     Given I have a configuration file with "theme" set to "test-theme"
     When I run jekyll+ extract assets/img/logo.png

--- a/lib/jekyll/commands/extract_theme.rb
+++ b/lib/jekyll/commands/extract_theme.rb
@@ -65,35 +65,32 @@ module Jekyll
       end
 
       def extract_to_source(path, options)
-        if File.directory?(path) && options["list"]
+        if File.directory?(path)
+          process_options_and_extract_directory path, options
+        else
+          process_options_and_extract_file path, options
+        end
+      end
+
+      def process_options_and_extract_directory(path, options)
+        if options["list"]
           list_contents path
-        elsif File.directory?(path) && options["root"] && !options["force"]
-          Jekyll.logger.warn "Attention:", "Using --root with directories will " \
-          "extract contents recursively and override corresponding file paths " \
-          "relative to your source directory. Please run the command again with " \
-          "--force to confirm."
-        elsif File.directory?(path) && options["root"] && options["force"]
-          Dir["#{path}/**/*"].each do |entry|
-            unless File.directory?(entry)
-              if File.exist?(File.join(@source, dir_content(path, entry)))
-                Jekyll.logger.warn "Overriding:", dir_content(path, entry)
-              else
-                print "Extracting:", dir_content(path, entry)
-              end
-            end
-          end
-          FileUtils.cp_r "#{path}/.", @source
-        elsif File.directory? path
+        elsif options["root"]
+          extract_dir_contents_to_root path, options
+        else
           dir_path = File.expand_path(path.split("/").last, @source)
           extract_directory dir_path, path, options
-        elsif !File.directory?(path) && options["list"]
+        end
+      end
+
+      def process_options_and_extract_file(path, options)
+        if options["list"]
           Jekyll.logger.warn "Error:", relative_path(path)
           Jekyll.logger.warn "", "The --list switch only works for directories"
-        elsif !File.directory?(path) && options["root"]
+        elsif options["root"]
           file_path = File.join(@source, File.basename(path))
-          if File.exist?(file_path) && !options["force"]
-            already_exists_msg File.basename(path)
-          else
+          extract_unless_exists(file_path, File.basename(path), options) do
+            print "Extracting:", relative_path(path)
             FileUtils.cp path, @source
           end
         else
@@ -113,9 +110,7 @@ module Jekyll
       end
 
       def extract_directory(dir_path, path, options)
-        if File.exist?(dir_path) && !options["force"]
-          already_exists_msg path
-        else
+        extract_unless_exists(dir_path, path, options) do
           FileUtils.cp_r path, @source
           directory = "#{relative_path(path).sub("/", "")} directory"
           print "Extracting:", directory
@@ -130,11 +125,37 @@ module Jekyll
       def extract_file_with_directory(dir_path, file_path, options)
         FileUtils.mkdir_p dir_path unless File.directory? dir_path
         file = file_path.split("/").last
-        if File.exist?(File.join(dir_path, file)) && !options["force"]
-          already_exists_msg file
-        else
+        extract_unless_exists(File.join(dir_path, file), file, options) do
           FileUtils.cp_r file_path, dir_path
           extraction_msg file_path
+        end
+      end
+
+      def extract_dir_contents_to_root(path, options)
+        if !options["force"]
+          Jekyll.logger.warn "Attention:", "Using --root with directories will " \
+          "extract contents recursively and override corresponding file paths " \
+          "relative to your source directory. Please run the command again with " \
+          "an additional --force to confirm."
+        elsif options["force"]
+          Dir["#{path}/**/*"].each do |entry|
+            unless File.directory?(entry)
+              if File.exist?(File.join(@source, dir_content(path, entry)))
+                Jekyll.logger.warn "Overriding:", dir_content(path, entry)
+              else
+                print "Extracting:", dir_content(path, entry)
+              end
+            end
+          end
+          FileUtils.cp_r "#{path}/.", @source
+        end
+      end
+
+      def extract_unless_exists(path, file, options)
+        if File.exist?(path) && !options["force"]
+          already_exists_msg file
+        else
+          yield
         end
       end
 


### PR DESCRIPTION
When supplied with the `--root` switch,` extract-theme` will copy a file directly to the site's `source` without creating any parent directory paths.

Attempting to do the same with contents of a sub-directory will only print a warning unless the `--force` switch is passed along with the `--root` switch.